### PR TITLE
Added C++ equivalent operation for computing row/colsums.

### DIFF
--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -1,0 +1,38 @@
+#include <random>
+#include <vector>
+#include <chrono>
+#include <iostream>
+#include <algorithm>
+#include "tatami/tatami.h"
+
+int main () {
+    // Generating a random matrix of 10000 x 10000 random unifs.
+    std::mt19937_64 generator;
+    std::uniform_real_distribution<double> distribution(0.0,1.0);
+
+    size_t m = 10000, n = 10000;
+    std::vector<double> source(m*n);
+    for (size_t i = 0; i < m*n; ++i) {
+        source[i] = distribution(generator);
+    }
+
+    auto start = std::chrono::high_resolution_clock::now();
+    std::shared_ptr<tatami::numeric_matrix> ptr(new tatami::DenseColumnMatrix<double>(m, n, std::move(source)));
+    auto stop = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
+    std::cout << "Construction:" << "\t" << duration.count() << std::endl;
+
+    start = std::chrono::high_resolution_clock::now();
+    auto routput = tatami::column_sums<double>(ptr.get());
+    stop = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
+    std::cout << "COLSUM: " << std::accumulate(routput.begin(), routput.end(), 0.0) << "\t" << duration.count() << std::endl;
+
+    start = std::chrono::high_resolution_clock::now();
+    auto coutput = tatami::row_sums(ptr.get());
+    stop = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
+    std::cout << "ROWSUM:" << std::accumulate(coutput.begin(), coutput.end(), 0.0) << "\t" << duration.count() << std::endl;
+
+    return 0;
+}

--- a/src/compute.js
+++ b/src/compute.js
@@ -1,20 +1,21 @@
 // generate a matrix of size n by m
-const n = 1000, m = 1000;
+const n = 10000, m = 10000;
 var matrix = [];
 
-function getRandomArbitrary(max) {
-    return Math.random() * max;
+function getRandomArbitrary() {
+    return Math.random();
 }
 
 for (var i = 0; i < n; i++) {
-    matrix[i] = new Uint16Array(m);
-    matrix[i] = matrix[i].map(() => getRandomArbitrary(255));
+    matrix[i] = new Float64Array(m);
+    matrix[i] = matrix[i].map(() => getRandomArbitrary());
 }
 
 // console.log(matrix);
 
 function colSum(matrix, order) {
-
+    console.log("##### COLSUM #####");
+    console.time("WHEE");
     var colSum;
 
     if (order) {
@@ -32,13 +33,14 @@ function colSum(matrix, order) {
     } else {
         colSum = matrix.reduce((x, y) => x.map((z, i) => z + y[i]));
     }
-    
-    console.log("##### COLSUM #####")
-    console.log(colSum);
+    console.timeEnd("WHEE");
+
     return colSum;
 }
 
 function rowSum(matrix, order) {
+    console.log("##### COLSUM #####");
+    console.time("WHEE");
     var rowSum;
     if (order) {
         var groups = order.filter((x, i, self) => self.indexOf(x) === i);
@@ -46,7 +48,6 @@ function rowSum(matrix, order) {
         groups.map((x,i) => {
             var indices = [];
             order.map((y ,j) => y == x ? indices.push(j) : false);
-
             if (indices.length == 1) {
                 rowSum.push(matrix[indices[0]]);
             } else {
@@ -57,13 +58,10 @@ function rowSum(matrix, order) {
         rowSum = matrix.map(z => z.reduce((x, y) => x + y));
     }
 
-    console.log("##### ROWSUM #####")
-    console.log(rowSum);
+    console.timeEnd("WHEE");
     return rowSum
 }
 
-rowSum(matrix, order = [1,2,1,2]);
 rowSum(matrix)
 // console.log("after row sum")
-colSum(matrix, order = [1,2,1,1]);
 colSum(matrix);


### PR DESCRIPTION
Compile by sticking the **tatami** library somewhere and then doing something like:

```sh
g++ -std=c++1z -I../../tatami/include compute.cpp # change include to path of tatami.
```

For me, this gives (in milliseconds - the first number prints the sum of sums, to avoid the compiler removing everything):

```
./a.out
## Construction:	302
## COLSUM: 5.00031e+07	240
## ROWSUM:5.00031e+07	456
```

while the modified JS (using `double`s for a valid comparison) gives:

```
node compute.js
## ##### COLSUM #####
## WHEE: 1509.588ms
## ##### COLSUM #####
## WHEE: 1742.449ms
```

So, about 3-6 times faster. Interestingly, the overall time is still lower for JS, I suspect because of differences in the PRNG. 